### PR TITLE
Feature/autocomplete 114

### DIFF
--- a/app/components/FileEditor/index.js
+++ b/app/components/FileEditor/index.js
@@ -16,7 +16,10 @@ import 'codemirror/addon/dialog/dialog'
 import 'codemirror/addon/scroll/annotatescrollbar'
 import 'codemirror/addon/search/matchesonscrollbar'
 import 'codemirror/mode/xml/xml'
+import 'codemirror/addon/hint/show-hint'
+import 'codemirror/addon/hint/xml-hint'
 import 'helpers/codemirror-util-autoformat'
+import { autocompleteTags, completeAfter, completeIfAfterLt, completeIfInTag } from 'helpers/codemirror-autocomplete-mjml'
 
 import foldByLevel from 'helpers/foldByLevel'
 import { fsReadFile, fsWriteFile } from 'helpers/fs'
@@ -145,6 +148,16 @@ class FileEditor extends Component {
         wordsOnly: true,
       },
       lineWrapping: wrapLines,
+      extraKeys: {
+        "'<'": completeAfter,
+        "'/'": completeIfAfterLt,
+        "' '": completeIfInTag,
+        "'='": completeIfInTag,
+        "Ctrl-Space": "autocomplete"
+      },
+      hintOptions: {
+        schemaInfo: autocompleteTags
+      }
     })
     this._codeMirror.on('change', this.handleChange)
   }

--- a/app/components/FileEditor/index.js
+++ b/app/components/FileEditor/index.js
@@ -149,15 +149,15 @@ class FileEditor extends Component {
       },
       lineWrapping: wrapLines,
       extraKeys: {
-        "'<'": completeAfter,
-        "'/'": completeIfAfterLt,
-        "' '": completeIfInTag,
-        "'='": completeIfInTag,
-        "Ctrl-Space": "autocomplete"
+        '"<"': completeAfter,
+        '"/"': completeIfAfterLt,
+        '" "': completeIfInTag,
+        '"="': completeIfInTag,
+        'Ctrl-Space': 'autocomplete',
       },
       hintOptions: {
-        schemaInfo: autocompleteTags
-      }
+        schemaInfo: autocompleteTags,
+      },
     })
     this._codeMirror.on('change', this.handleChange)
   }

--- a/app/components/FileEditor/index.js
+++ b/app/components/FileEditor/index.js
@@ -153,11 +153,11 @@ class FileEditor extends Component {
         "'/'": completeIfAfterLt,
         "' '": completeIfInTag,
         "'='": completeIfInTag,
-        'Ctrl-Space': 'autocomplete'
+        'Ctrl-Space': 'autocomplete',
       },
       hintOptions: {
-        schemaInfo: autocompleteTags
-      }
+        schemaInfo: autocompleteTags,
+      },
     })
     this._codeMirror.on('change', this.handleChange)
   }

--- a/app/components/FileEditor/index.js
+++ b/app/components/FileEditor/index.js
@@ -149,15 +149,15 @@ class FileEditor extends Component {
       },
       lineWrapping: wrapLines,
       extraKeys: {
-        '"<"': completeAfter,
-        '"/"': completeIfAfterLt,
-        '" "': completeIfInTag,
-        '"="': completeIfInTag,
-        'Ctrl-Space': 'autocomplete',
+        "'<'": completeAfter,
+        "'/'": completeIfAfterLt,
+        "' '": completeIfInTag,
+        "'='": completeIfInTag,
+        'Ctrl-Space': 'autocomplete'
       },
       hintOptions: {
-        schemaInfo: autocompleteTags,
-      },
+        schemaInfo: autocompleteTags
+      }
     })
     this._codeMirror.on('change', this.handleChange)
   }

--- a/app/components/FileEditor/styles.scss
+++ b/app/components/FileEditor/styles.scss
@@ -1,4 +1,5 @@
 @import "~codemirror/lib/codemirror.css";
+@import "~codemirror/addon/hint/show-hint.css";
 @import "../../styles/one-dark.scss";
 @import "../../styles/vars.scss";
 
@@ -20,6 +21,21 @@
       pointer-events: auto;
     }
   }
+}
+
+.CodeMirror-hints {
+  border: none;
+  background: $bg;
+}
+
+.CodeMirror-hint {
+  color: $almostWhite;
+  padding: 5px;
+}
+
+li.CodeMirror-hint-active {
+  background-color: rgba($blue, 0.1) !important;
+  color: $blue;
 }
 
 .FileEditor--loader {

--- a/app/helpers/codemirror-autocomplete-mjml.js
+++ b/app/helpers/codemirror-autocomplete-mjml.js
@@ -1,35 +1,40 @@
 /* eslint-disable */
 import CodeMirror from 'codemirror'
 
-const tags = {
+const tags = { 
   'mj-accordion': {},
-  'mj-attributes': {},
-  'mj-body': {},
+  'mj-accordion-element': {},
+  'mj-accordion-title': {},
+  'mj-accordion-text': {},
   'mj-button': {},
   'mj-carousel': {},
+  'mj-carousel-image': {},
   'mj-column': {},
   'mj-container': {},
-  'mj-core': {},
   'mj-divider': {},
-  'mj-font': {},
   'mj-group': {},
-  'mj-head': {},
+  'mj-attributes': {},
+  'mj-font': {},
+  'mj-style': {},
+  'mj-title': {},
   'mj-hero': {},
+  'mj-hero-content': {},
   'mj-html': {},
   'mj-image': {},
   'mj-invoice': {},
+  'mj-invoice-item': {},
   'mj-list': {},
   'mj-location': {},
   'mj-navbar': {},
+  'mj-inline-links': {},
+  'mj-link': {},
   'mj-raw': {},
   'mj-section': {},
   'mj-social': {},
   'mj-spacer': {},
-  'mj-style': {},
   'mj-table': {},
   'mj-text': {},
-  'mj-title': {},
-  'mj-wrapper': {},
+  'mj-wrapper': {} 
 }
 
 export function completeAfter(cm, pred) {

--- a/app/helpers/codemirror-autocomplete-mjml.js
+++ b/app/helpers/codemirror-autocomplete-mjml.js
@@ -1,0 +1,57 @@
+import CodeMirror from 'codemirror'
+
+const tags = {
+  "mj-accordion": {},
+  "mj-body": {},
+  "mj-button": {},
+  "mj-carousel": {},
+  "mj-cli": {},
+  "mj-column": {},
+  "mj-container": {},
+  "mj-core": {},
+  "mj-divider": {},
+  "mj-group": {},
+  "mj-head-attributes": {},
+  "mj-head-font": {},
+  "mj-head-style": {},
+  "mj-head-title": {},
+  "mj-hero": {},
+  "mj-html": {},
+  "mj-image": {},
+  "mj-invoice": {},
+  "mj-list": {},
+  "mj-location": {},
+  "mj-navbar": {},
+  "mj-raw": {},
+  "mj-section": {},
+  "mj-social": {},
+  "mj-spacer": {},
+  "mj-table": {},
+  "mj-text": {},
+  "mj-wrapper": {},
+};
+
+export function completeAfter(cm, pred) {
+  var cur = cm.getCursor();
+  if (!pred || pred()) setTimeout(function() {
+    if (!cm.state.completionActive)
+      cm.showHint({completeSingle: false});
+  }, 100);
+  return CodeMirror.Pass;
+}
+export function completeIfAfterLt(cm) {
+  return completeAfter(cm, function() {
+    var cur = cm.getCursor();
+    return cm.getRange(CodeMirror.Pos(cur.line, cur.ch - 1), cur) == "<";
+  });
+}
+export function completeIfInTag(cm) {
+  return completeAfter(cm, function() {
+    var tok = cm.getTokenAt(cm.getCursor());
+    if (tok.type == "string" && (!/['"]/.test(tok.string.charAt(tok.string.length - 1)) || tok.string.length == 1)) return false;
+    var inner = CodeMirror.innerMode(cm.getMode(), tok.state).state;
+    return inner.tagName;
+  });
+}
+
+exports.autocompleteTags = tags

--- a/app/helpers/codemirror-autocomplete-mjml.js
+++ b/app/helpers/codemirror-autocomplete-mjml.js
@@ -3,19 +3,17 @@ import CodeMirror from 'codemirror'
 
 const tags = {
   'mj-accordion': {},
+  'mj-attributes': {},
   'mj-body': {},
   'mj-button': {},
   'mj-carousel': {},
-  'mj-cli': {},
   'mj-column': {},
   'mj-container': {},
   'mj-core': {},
   'mj-divider': {},
+  'mj-font': {},
   'mj-group': {},
-  'mj-head-attributes': {},
-  'mj-head-font': {},
-  'mj-head-style': {},
-  'mj-head-title': {},
+  'mj-head': {},
   'mj-hero': {},
   'mj-html': {},
   'mj-image': {},
@@ -27,8 +25,10 @@ const tags = {
   'mj-section': {},
   'mj-social': {},
   'mj-spacer': {},
+  'mj-style': {},
   'mj-table': {},
   'mj-text': {},
+  'mj-title': {},
   'mj-wrapper': {},
 }
 

--- a/app/helpers/codemirror-autocomplete-mjml.js
+++ b/app/helpers/codemirror-autocomplete-mjml.js
@@ -30,7 +30,7 @@ const tags = {
   'mj-table': {},
   'mj-text': {},
   'mj-wrapper': {},
-};
+}
 
 export function completeAfter(cm, pred) {
   var cur = cm.getCursor();

--- a/app/helpers/codemirror-autocomplete-mjml.js
+++ b/app/helpers/codemirror-autocomplete-mjml.js
@@ -1,34 +1,35 @@
+/* eslint-disable */
 import CodeMirror from 'codemirror'
 
 const tags = {
-  "mj-accordion": {},
-  "mj-body": {},
-  "mj-button": {},
-  "mj-carousel": {},
-  "mj-cli": {},
-  "mj-column": {},
-  "mj-container": {},
-  "mj-core": {},
-  "mj-divider": {},
-  "mj-group": {},
-  "mj-head-attributes": {},
-  "mj-head-font": {},
-  "mj-head-style": {},
-  "mj-head-title": {},
-  "mj-hero": {},
-  "mj-html": {},
-  "mj-image": {},
-  "mj-invoice": {},
-  "mj-list": {},
-  "mj-location": {},
-  "mj-navbar": {},
-  "mj-raw": {},
-  "mj-section": {},
-  "mj-social": {},
-  "mj-spacer": {},
-  "mj-table": {},
-  "mj-text": {},
-  "mj-wrapper": {},
+  'mj-accordion': {},
+  'mj-body': {},
+  'mj-button': {},
+  'mj-carousel': {},
+  'mj-cli': {},
+  'mj-column': {},
+  'mj-container': {},
+  'mj-core': {},
+  'mj-divider': {},
+  'mj-group': {},
+  'mj-head-attributes': {},
+  'mj-head-font': {},
+  'mj-head-style': {},
+  'mj-head-title': {},
+  'mj-hero': {},
+  'mj-html': {},
+  'mj-image': {},
+  'mj-invoice': {},
+  'mj-list': {},
+  'mj-location': {},
+  'mj-navbar': {},
+  'mj-raw': {},
+  'mj-section': {},
+  'mj-social': {},
+  'mj-spacer': {},
+  'mj-table': {},
+  'mj-text': {},
+  'mj-wrapper': {},
 };
 
 export function completeAfter(cm, pred) {
@@ -42,13 +43,13 @@ export function completeAfter(cm, pred) {
 export function completeIfAfterLt(cm) {
   return completeAfter(cm, function() {
     var cur = cm.getCursor();
-    return cm.getRange(CodeMirror.Pos(cur.line, cur.ch - 1), cur) == "<";
+    return cm.getRange(CodeMirror.Pos(cur.line, cur.ch - 1), cur) == '<';
   });
 }
 export function completeIfInTag(cm) {
   return completeAfter(cm, function() {
     var tok = cm.getTokenAt(cm.getCursor());
-    if (tok.type == "string" && (!/['"]/.test(tok.string.charAt(tok.string.length - 1)) || tok.string.length == 1)) return false;
+    if (tok.type == 'string' && (!/['"]/.test(tok.string.charAt(tok.string.length - 1)) || tok.string.length == 1)) return false;
     var inner = CodeMirror.innerMode(cm.getMode(), tok.state).state;
     return inner.tagName;
   });


### PR DESCRIPTION
First tentative for autocomplete. 

- When a tag is opened with `<`, a dropdown with all mjml tags is shown
- When a tag is selected in the dropdown (with tab, enter or ctrl+space), it's autocompleted without the final `>` of the opening tag. The user has to type `>` to trigger autoclose, I think it can make sense as users might want to add attributes when opening a tag?
- If a user edits a tag that was already autocompleted (example delete `dy` in `<mj-body`), the drowdown is not shown anymore. However, autocomplete can be triggered with ctrl+space (showing dropdown if several components matching or autocompleted if only one component matching)

Possible improvements:

1. only display the tags that can be used within a parent (respecting MJML parent/children relationships)
2. provide autocomplete for attributes available for the MJML component being edited
3. enable to add custom components tag names in autocompletion
4. allow to enable/disable autocompletion in settings

I think those can be interesting but tricky as:

1. is quite restricting
2. can be demanding in terms of maintenance (or we'd have to parse the MJML documentation...?)

![](http://g.recordit.co/BD4exrcBFT.gif)
