### PR TITLE
Adding Try-it-live to menu

### DIFF
--- a/app/menu.js
+++ b/app/menu.js
@@ -27,6 +27,11 @@ export default function buildMenu (mainWindow) {
           shell.openItem('https://mjml.io/documentation/')
         },
       }, {
+        label: 'Browser Editor',
+        click () {
+          shell.openItem('https://mjml.io/try-it-live')
+        },
+      }, {
         type: 'separator',
       }, {
         label: 'Quit MJML',


### PR DESCRIPTION
Proposition to add Try-it-live editor to menu of the app, as it is good was to share working code with colleagues (and, for now, use error checker, until it is not implemented in app).

I proposed name "Browser Editor", as not all may know what is "Try-it-live" as the app gives "live" changes.