### PR TITLE
[do not merge] Local images fix

### DIFF
--- a/app/components/Iframe/index.js
+++ b/app/components/Iframe/index.js
@@ -62,6 +62,27 @@ class Iframe extends Component {
             img.setAttribute('src', `file://${base}/${imgSrc}`)
           }
         })
+        
+        const tables = [...documentElement.querySelectorAll('table')]
+        tables.forEach(table => {
+          if (table.getAttribute('background')) {
+            const tableBackground = table.getAttribute('background')
+            if (tableBackground && !tableBackground.startsWith('http')) {
+              table.setAttribute('background', `file://${base}/${tableBackground}`)
+            }
+          }
+        })
+        
+        const tds = [...documentElement.querySelectorAll('td')]
+        tds.forEach(td => {
+          if (td.getAttribute('background')) {
+            const tdBackground = td.getAttribute('background')
+            if (tdBackground && !tdBackground.startsWith('http')) {
+              let tdStyle = td.getAttribute('style').replace(tdBackground, `file://${base}/${tdBackground}`)
+              td.setAttribute('style', tdStyle)
+            }
+          }
+        })
       }
 
     })


### PR DESCRIPTION
Hello, 

I noticed that local images' paths are only replaced in the HTML `img` tag. This means it doesn't work for local images used as a background-image in `mj-wrapper`, `mj-section` and `mj-hero`. 

Basically, when a background-image is used, its path is set in the HTML in 3 places:
- in the VML for Outlook
- in the `background` attribute on the `table` (`mj-section`) or on the `td` (`mj-hero`)
- in the `style` attribute (`background url(...)`) on the `table` (`mj-section`) or on the `td` (`mj-hero`) 

The preview pane shows the image set via the `style` attribute of the `td` on `mj-hero` while it shows the image set via the `background` attribute on the `table` for `mj-section`. 

However, perfs of this PR seems to be pretty bad :/