### PR TITLE
Added SenderName routines and UI block

### DIFF
--- a/app/actions/settings.js
+++ b/app/actions/settings.js
@@ -35,6 +35,7 @@ export function loadSettings() {
         Subject: 'MJML App test email',
         APIKey: '',
         APISecret: '',
+        SenderName: 'MJML App',
         SenderEmail: '',
         TargetEmails: [],
         LastEmails: [],

--- a/app/components/MailjetInfos.js
+++ b/app/components/MailjetInfos.js
@@ -7,9 +7,8 @@ import LogoMailjet from 'components/icons/logo-mailjet'
 
 class MailjetInfos extends Component {
   state = {
-    isOpened: (({ APIKey, APISecret, SenderName, SenderEmail }) => !APIKey || !APISecret || !SenderName || !SenderEmail)(
-      this.props,
-    ),
+    isOpened: (({ APIKey, APISecret, SenderName, SenderEmail }) =>
+      !APIKey || !APISecret || !SenderName || !SenderEmail)(this.props),
   }
 
   handleOpenInfos = e => {

--- a/app/components/MailjetInfos.js
+++ b/app/components/MailjetInfos.js
@@ -7,7 +7,7 @@ import LogoMailjet from 'components/icons/logo-mailjet'
 
 class MailjetInfos extends Component {
   state = {
-    isOpened: (({ APIKey, APISecret, SenderEmail }) => !APIKey || !APISecret || !SenderEmail)(
+    isOpened: (({ APIKey, APISecret, SenderName, SenderEmail }) => !APIKey || !APISecret || !SenderName || !SenderEmail)(
       this.props,
     ),
   }
@@ -29,7 +29,7 @@ class MailjetInfos extends Component {
   }
 
   render() {
-    const { SenderEmail, APIKey, APISecret } = this.props
+    const { SenderName, SenderEmail, APIKey, APISecret } = this.props
 
     const { isOpened } = this.state
 
@@ -95,6 +95,20 @@ class MailjetInfos extends Component {
                   value={APISecret}
                   onChange={this.handleChangeInput('APISecret')}
                   placeholder="Mailjet API Secret"
+                  type="text"
+                />
+              </div>
+
+              <div className="d-f ai-b">
+                <div style={{ width: 150 }} className="fs-0 t-small">
+                  {!SenderName && <span className="red-star">{'*'}</span>}
+                  {'Sender Name:'}
+                </div>
+                <input
+                  className="fg-1"
+                  value={SenderName}
+                  onChange={this.handleChangeInput('SenderName')}
+                  placeholder="SenderName"
                   type="text"
                 />
               </div>

--- a/app/helpers/sendEmail.js
+++ b/app/helpers/sendEmail.js
@@ -1,7 +1,7 @@
 import nodeMailjet from 'node-mailjet'
 
 export default function sendEmail(opts) {
-  const { content, Subject, APIKey, APISecret, SenderEmail, TargetEmails } = opts
+  const { content, Subject, APIKey, APISecret, SenderName, SenderEmail, TargetEmails } = opts
 
   const mj = nodeMailjet.connect(APIKey, APISecret)
   const send = mj.post('send')
@@ -9,7 +9,7 @@ export default function sendEmail(opts) {
 
   return send.request({
     FromEmail: SenderEmail,
-    FromName: 'MJML App',
+    FromName: SenderName,
     Subject,
     'Html-part': content,
     Recipients,

--- a/app/pages/Project/SendModal.js
+++ b/app/pages/Project/SendModal.js
@@ -178,7 +178,8 @@ class SendModal extends Component {
 
     const { emails, Subject, APIKey, APISecret, SenderName, SenderEmail, TargetEmails } = this.state
 
-    const isValid = !!APIKey && !!APISecret && !!SenderName && !!SenderEmail && !!TargetEmails.length && !!Subject
+    const isValid =
+      !!APIKey && !!APISecret && !!SenderName && !!SenderEmail && !!TargetEmails.length && !!Subject
 
     return (
       <Modal isOpened={isOpened} onClose={this.handleClose}>

--- a/app/pages/Project/SendModal.js
+++ b/app/pages/Project/SendModal.js
@@ -20,6 +20,7 @@ import Button from 'components/Button'
 
 @connect(
   state => {
+    const SenderName = state.settings.getIn(['api', 'SenderName'], '')
     const SenderEmail = state.settings.getIn(['api', 'SenderEmail'], '')
     const TargetEmails = state.settings.getIn(['api', 'TargetEmails'], [])
     const LastEmails = state.settings.getIn(['api', 'LastEmails'], [])
@@ -30,6 +31,7 @@ import Button from 'components/Button'
       APIKey: state.settings.getIn(['api', 'APIKey'], ''),
       APISecret: state.settings.getIn(['api', 'APISecret'], ''),
       Subject,
+      SenderName,
       SenderEmail,
       TargetEmails,
       emails: uniq([
@@ -53,6 +55,7 @@ class SendModal extends Component {
     Subject: '',
     APIKey: '',
     APISecret: '',
+    SenderName: '',
     SenderEmail: '',
     TargetEmails: [],
   }
@@ -97,7 +100,7 @@ class SendModal extends Component {
 
     const { addAlert, content } = this.props
 
-    const { Subject, APIKey, APISecret, SenderEmail, TargetEmails } = this.state
+    const { Subject, APIKey, APISecret, SenderName, SenderEmail, TargetEmails } = this.state
 
     try {
       await sendEmail({
@@ -105,6 +108,7 @@ class SendModal extends Component {
         Subject,
         APIKey,
         APISecret,
+        SenderName,
         SenderEmail,
         TargetEmails,
       })
@@ -129,6 +133,7 @@ class SendModal extends Component {
       Subject: props.Subject,
       APIKey: props.APIKey,
       APISecret: props.APISecret,
+      SenderName: props.SenderName,
       SenderEmail: props.SenderEmail,
       TargetEmails: props.TargetEmails,
     })
@@ -140,6 +145,7 @@ class SendModal extends Component {
         .setIn(['api', 'Subject'], this.state.Subject)
         .setIn(['api', 'APIKey'], this.state.APIKey)
         .setIn(['api', 'APISecret'], this.state.APISecret)
+        .setIn(['api', 'SenderName'], this.state.SenderName)
         .setIn(['api', 'SenderEmail'], this.state.SenderEmail)
         .setIn(['api', 'TargetEmails'], this.state.TargetEmails)
     })
@@ -170,9 +176,9 @@ class SendModal extends Component {
   render() {
     const { isOpened } = this.props
 
-    const { emails, Subject, APIKey, APISecret, SenderEmail, TargetEmails } = this.state
+    const { emails, Subject, APIKey, APISecret, SenderName, SenderEmail, TargetEmails } = this.state
 
-    const isValid = !!APIKey && !!APISecret && !!SenderEmail && !!TargetEmails.length && !!Subject
+    const isValid = !!APIKey && !!APISecret && !!SenderName && !!SenderEmail && !!TargetEmails.length && !!Subject
 
     return (
       <Modal isOpened={isOpened} onClose={this.handleClose}>
@@ -182,6 +188,7 @@ class SendModal extends Component {
           <MailjetInfos
             APIKey={APIKey}
             APISecret={APISecret}
+            SenderName={SenderName}
             SenderEmail={SenderEmail}
             onChange={this.handleChangeInfo}
           />


### PR DESCRIPTION
Here there's the barebone commit.
1st time I actually work with electron and still newbie with ES6, double check before merging!

- handleChangeInput = key => e => ... trims on every change, for the name it should be possible to put spaces before adding another word (not possible right now).

I could have implemented another "handleChangeSoftTrim(...)" or load the state and trim at the end of the operation but it looks a bit hacky. Plus I just want to focus on one at at time.