### PR TITLE
typo fix: screeshot -> screenshot

### DIFF
--- a/app/pages/Project/index.js
+++ b/app/pages/Project/index.js
@@ -222,7 +222,7 @@ class ProjectPage extends Component {
                     {
                       icon: <IconCamera />,
                       label: 'Screenshot',
-                      desc: 'Save a screeshot of mobile & desktop result',
+                      desc: 'Save a screenshot of mobile & desktop result',
                       onClick: this.handleScreenshot,
                     },
                   ]}


### PR DESCRIPTION
In the upper right dropdown menu, where 'Copy as HTML' and 'Screenshot' are located, screenshot was misspelled.