### PR TITLE
change path of tmp file for screenshots to respect relative paths

### DIFF
--- a/src/helpers/fs.js
+++ b/src/helpers/fs.js
@@ -14,6 +14,7 @@ export const fsWriteFile = promisify(fs.writeFile)
 export const fsAccess = promisify(fs.access)
 export const fsStat = promisify(fs.stat)
 export const fsMkdir = promisify(fs.mkdir)
+export const fsUnlink = promisify(fs.unlink)
 export const recursiveCopy = promisify(ncp)
 
 function getFileInfoFactory(p) {

--- a/src/helpers/takeScreenshot.js
+++ b/src/helpers/takeScreenshot.js
@@ -2,18 +2,18 @@ import { remote } from 'electron'
 import path from 'path'
 import os from 'os'
 
-import { fsWriteFile } from 'helpers/fs'
+import { fsWriteFile, fsUnlink } from 'helpers/fs'
 
-const TMP_DIR = os.tmpdir()
+const TMP_FILE = 'tpm-mjml-preview.html'
 
-export default function takeScreenshot(html, deviceWidth) {
+export function takeScreenshot(html, deviceWidth, workingDirectory) {
   return new Promise(async resolve => {
     const win = new remote.BrowserWindow({
       width: deviceWidth,
       show: false,
     })
 
-    const tmpFileName = path.join(TMP_DIR, 'tpm-mjml-preview.html')
+    const tmpFileName = path.join(workingDirectory, TMP_FILE)
     await fsWriteFile(tmpFileName, html)
 
     win.loadURL(`file://${tmpFileName}`)
@@ -36,4 +36,9 @@ export default function takeScreenshot(html, deviceWidth) {
       )
     })
   })
+}
+
+export async function cleanUp(workingDirectory) {
+  const tmpFileName = path.join(workingDirectory, TMP_FILE)
+  await fsUnlink(tmpFileName)
 }

--- a/src/helpers/takeScreenshot.js
+++ b/src/helpers/takeScreenshot.js
@@ -1,6 +1,5 @@
 import { remote } from 'electron'
 import path from 'path'
-import os from 'os'
 
 import { fsWriteFile, fsUnlink } from 'helpers/fs'
 

--- a/src/pages/Project/index.js
+++ b/src/pages/Project/index.js
@@ -31,7 +31,7 @@ import SendModal from './SendModal'
 import AddFileModal from './AddFileModal'
 import RemoveFileModal from './RemoveFileModal'
 
-import takeScreenshot from 'helpers/takeScreenshot'
+import { takeScreenshot, cleanUp } from 'helpers/takeScreenshot'
 
 @connect(
   state => ({
@@ -150,9 +150,11 @@ class ProjectPage extends Component {
     const [mobileWidth, desktopWidth] = [previewSize.get('mobile'), previewSize.get('desktop')]
 
     const [mobileScreenshot, desktopScreenshot] = await Promise.all([
-      takeScreenshot(preview.content, mobileWidth),
-      takeScreenshot(preview.content, desktopWidth),
+      takeScreenshot(preview.content, mobileWidth, this.state.path),
+      takeScreenshot(preview.content, desktopWidth, this.state.path),
     ])
+
+    await cleanUp(this.state.path)
 
     await Promise.all([
       fsWriteFile(pathModule.join(location.query.path, `${filename}-mobile.png`), mobileScreenshot),


### PR DESCRIPTION
This is a "problem" we had when saving a screenshot for a file, which e.g. has relative path to images in the current working folder /root/emailA/... while the project folder is /root. Then the images are not displayed as the temporary file is sitting in some temporary folder of the OS. I changed it so that the temporary file is saved in the working folder. After taking all screenshots the file is deleted.

Of course one should never deploy a html file with relative folder, however during testing the marketing team might want to send some screenshots and in this case having the relative paths for images etc. is crucial.

Idea for another ticket: Having the HTML export actually warn via a dialog or so if relative paths were detected in the export ;)