### PR TITLE
fix detectOldSyntax button appearance

### DIFF
--- a/src/components/FileEditor/index.js
+++ b/src/components/FileEditor/index.js
@@ -143,9 +143,7 @@ class FileEditor extends Component {
 
   detecteOldSyntax = () => {
     const content = this.getContent()
-    if (isOldSyntax(content)) {
-      this.props.onDetectOldSyntax()
-    }
+    this.props.onDetectOldSyntax(isOldSyntax(content))
   }
 
   async loadContent() {
@@ -253,6 +251,8 @@ class FileEditor extends Component {
       await fsWriteFile(fileName, mjml)
       setPreview(fileName, mjml)
     }
+
+    window.requestIdleCallback(this.detecteOldSyntax)
   }, 200)
 
   getContent = () => {

--- a/src/components/FilesList/index.js
+++ b/src/components/FilesList/index.js
@@ -85,7 +85,7 @@ class FilesList extends Component {
     ipcRenderer.removeListener('browser-window-focus', this.refresh)
   }
 
-  handleDetectOldSyntax = () => this.setState({ isOldSyntaxDetected: true })
+  handleDetectOldSyntax = val => this.setState({ isOldSyntaxDetected: val })
 
   handleSubmit = e => {
     e.preventDefault()


### PR DESCRIPTION
The "migrate" button was not appearing/disappearing on change/load file