### PR TITLE
Fix 273

### DIFF
--- a/src/components/FileEditor/index.js
+++ b/src/components/FileEditor/index.js
@@ -27,6 +27,8 @@ import 'helpers/codemirror-util-autoformat'
 
 import isOldSyntax from 'helpers/detectOldMJMLSyntax'
 
+import { codeMirrorCtrlD, codeMirrorDuplicate } from 'helpers/codemirror-shortcuts'
+
 import {
   completeAfter,
   completeIfAfterLt,
@@ -176,6 +178,14 @@ class FileEditor extends Component {
       this.setState({ isLoading: false })
     } catch (e) {} // eslint-disable-line
   }
+  
+  handleCtrlD(cm) {
+    codeMirrorCtrlD(cm, this._codeMirror)
+  }
+
+  handleCtrlShiftD(cm) {
+    codeMirrorDuplicate(cm, this._codeMirror)
+  }
 
   initEditor() {
     if (!this._textarea) {
@@ -215,6 +225,10 @@ class FileEditor extends Component {
         "' '": cm => completeIfInTag(CodeMirror, cm),
         "'='": cm => completeIfInTag(CodeMirror, cm),
         'Ctrl-Space': 'autocomplete',
+        'Ctrl-D': cm => this.handleCtrlD(cm),
+        'Cmd-D': cm => this.handleCtrlD(cm),
+        'Shift-Ctrl-D': cm => this.handleCtrlShiftD(cm),
+        'Shift-Cmd-D': cm => this.handleCtrlShiftD(cm),
         /* eslint-enable quotes */
       },
       lint: this.handleValidate,

--- a/src/components/FileEditor/index.js
+++ b/src/components/FileEditor/index.js
@@ -178,7 +178,7 @@ class FileEditor extends Component {
       this.setState({ isLoading: false })
     } catch (e) {} // eslint-disable-line
   }
-  
+
   handleCtrlD(cm) {
     codeMirrorCtrlD(cm, this._codeMirror)
   }

--- a/src/helpers/codemirror-shortcuts.js
+++ b/src/helpers/codemirror-shortcuts.js
@@ -9,7 +9,8 @@ export const codeMirrorCtrlD = (cm, doc) => {
     let found = false
     let match
 
-    while (!found && (match = reg.exec(lineContent))) { // eslint-disable-line no-cond-assign
+    // eslint-disable-next-line no-cond-assign
+    while (!found && (match = reg.exec(lineContent))) {
       if (ch >= match.index && ch <= reg.lastIndex) {
         found = true
 

--- a/src/helpers/codemirror-shortcuts.js
+++ b/src/helpers/codemirror-shortcuts.js
@@ -1,0 +1,120 @@
+import { last, maxBy } from 'lodash'
+
+export const codeMirrorCtrlD = (cm, doc) => {
+  if (!cm.somethingSelected()) {
+    // If nothing selected yet, select the word around the cursor
+    const { ch, line } = cm.getCursor()
+    const lineContent = cm.getLine(line)
+    const reg = /([\d\w-_]+)/g
+    let found = false
+    let match
+
+    while (!found && (match = reg.exec(lineContent))) {
+      if (ch >= match.index && ch <= reg.lastIndex) {
+        found = true
+
+        cm.setSelection(
+          {
+            line,
+            ch: match.index,
+          },
+          {
+            line,
+            ch: reg.lastIndex,
+          },
+        )
+      }
+    }
+  } else {
+    // Search and select next occurence
+    const selectionValue = cm.getSelections()[0]
+    const selections = cm.listSelections()
+    const lastSelection = last(selections)
+
+    // don't support if multiline
+    if (lastSelection.anchor.line !== lastSelection.head.line) return
+
+    const lastPos = maxBy([lastSelection.head, lastSelection.anchor], 'ch')
+    let lineNb = lastPos.line
+    let found = false
+
+    const handleLine = ({ text }) => {
+      if (!found) {
+        let index
+
+        if (lineNb === lastPos.line) {
+          index = text.substring(lastPos.ch).indexOf(selectionValue)
+
+          if (index !== -1) index = index + lastPos.ch
+        } else {
+          index = text.indexOf(selectionValue)
+        }
+
+        if (index !== -1) {
+          found = true
+          cm.setSelections(
+            [
+              ...selections,
+              {
+                anchor: {
+                  line: lineNb,
+                  ch: index,
+                },
+                head: {
+                  line: lineNb,
+                  ch: index + selectionValue.length,
+                },
+              },
+            ],
+            selections.length,
+          )
+        }
+      }
+      lineNb++
+    }
+
+    doc.eachLine(lastPos.line, cm.lastLine(), handleLine)
+
+    // Start again from beginning
+    if (!found) {
+      lineNb = 0
+      doc.eachLine(0, lastPos.line, handleLine)
+    }
+  }
+}
+
+export const codeMirrorDuplicate = (cm, doc) => {
+  if (!cm.somethingSelected()) {
+    // If nothing selected, duplicate current line
+    const { ch, line } = cm.getCursor()
+    const lineContent = cm.getLine(line)
+
+    doc.replaceRange(`${lineContent}\n`, { line, ch: 0 })
+    return
+  }
+
+  const selections = cm.listSelections()
+
+  selections.forEach((selection, i) => {
+    // Get up-to-date selection because previous loops changed line numbers
+    const select = i === 0 ? selection : cm.listSelections()[i]
+
+    // if single line, duplicate line
+    if (select.anchor.line === select.head.line) {
+      const line = select.head.line
+      const lineContent = cm.getLine(line)
+
+      doc.replaceRange(`${lineContent}\n`, { line, ch: 0 })
+      return
+    }
+
+    // if multiline, duplicate all lines of the selection (full line, regardless of the selection)
+    const lineNumbers = [select.head.line, select.anchor.line].sort()
+    let lines = ''
+    doc.eachLine(lineNumbers[0], lineNumbers[1] + 1, line => {
+      lines += `${line.text}\n`
+    })
+
+    doc.replaceRange(`${lines}`, { line: lineNumbers[0], ch: 0 })
+  })
+}

--- a/src/helpers/codemirror-shortcuts.js
+++ b/src/helpers/codemirror-shortcuts.js
@@ -9,7 +9,7 @@ export const codeMirrorCtrlD = (cm, doc) => {
     let found = false
     let match
 
-    while (!found && (match = reg.exec(lineContent))) {
+    while (!found && (match = reg.exec(lineContent))) { // eslint-disable-line no-cond-assign
       if (ch >= match.index && ch <= reg.lastIndex) {
         found = true
 
@@ -45,7 +45,7 @@ export const codeMirrorCtrlD = (cm, doc) => {
         if (lineNb === lastPos.line) {
           index = text.substring(lastPos.ch).indexOf(selectionValue)
 
-          if (index !== -1) index = index + lastPos.ch
+          if (index !== -1) index += lastPos.ch
         } else {
           index = text.indexOf(selectionValue)
         }
@@ -86,7 +86,7 @@ export const codeMirrorCtrlD = (cm, doc) => {
 export const codeMirrorDuplicate = (cm, doc) => {
   if (!cm.somethingSelected()) {
     // If nothing selected, duplicate current line
-    const { ch, line } = cm.getCursor()
+    const { line } = cm.getCursor()
     const lineContent = cm.getLine(line)
 
     doc.replaceRange(`${lineContent}\n`, { line, ch: 0 })
@@ -101,7 +101,7 @@ export const codeMirrorDuplicate = (cm, doc) => {
 
     // if single line, duplicate line
     if (select.anchor.line === select.head.line) {
-      const line = select.head.line
+      const { line } = select.head
       const lineContent = cm.getLine(line)
 
       doc.replaceRange(`${lineContent}\n`, { line, ch: 0 })


### PR DESCRIPTION
reproduce `ctrl+D` and `shift+ctrl+D` shortcuts from our beloved editors
for Ctrl+D when no current selection, it selects the word around the cursor, which characters should be considered as non word-breaker ?
For now the regex allows \d\w-_
Maybe we should add # for color selection ? Do you see any others ?
Or maybe we should do the opposite way and specify the "breakers" (space, ", {, (, etc.) ?