### PR TITLE
keepComments Option in Settings

### DIFF
--- a/src/actions/settings.js
+++ b/src/actions/settings.js
@@ -40,6 +40,7 @@ export function loadSettings() {
       mjml: {
         minify: false,
         beautify: false,
+        keepComments: true,
         checkForRelativePaths: false,
       },
       projects: [],

--- a/src/components/SettingsModal/index.js
+++ b/src/components/SettingsModal/index.js
@@ -95,6 +95,7 @@ class SettingsModal extends Component {
     const editorLightTheme = settings.getIn(['editor', 'lightTheme'], false)
     const minifyOutput = settings.getIn(['mjml', 'minify'], false)
     const beautifyOutput = settings.getIn(['mjml', 'beautify'], false)
+    const keepCommentsOutput = settings.getIn(['mjml', 'keepComments'], true)
     const editorUseTab = settings.getIn(['editor', 'useTab'], false)
     const editorTabSize = settings.getIn(['editor', 'tabSize'], 2)
     const editorIndentSize = settings.getIn(['editor', 'indentSize'], 2)
@@ -128,6 +129,9 @@ class SettingsModal extends Component {
               </CheckBox>
               <CheckBox value={beautifyOutput} onChange={this.changeMJMLSetting('beautify')}>
                 {'Beautify HTML output'}
+              </CheckBox>
+              <CheckBox value={keepCommentsOutput} onChange={this.changeMJMLSetting('keepComments')}>
+                {'Preserve HTML comments in output'}
               </CheckBox>
               <CheckBox
                 className="tooltip-trigger"

--- a/src/components/SettingsModal/index.js
+++ b/src/components/SettingsModal/index.js
@@ -130,7 +130,10 @@ class SettingsModal extends Component {
               <CheckBox value={beautifyOutput} onChange={this.changeMJMLSetting('beautify')}>
                 {'Beautify HTML output'}
               </CheckBox>
-              <CheckBox value={keepCommentsOutput} onChange={this.changeMJMLSetting('keepComments')}>
+              <CheckBox
+                value={keepCommentsOutput}
+                onChange={this.changeMJMLSetting('keepComments')}
+              >
                 {'Preserve HTML comments in output'}
               </CheckBox>
               <CheckBox

--- a/src/helpers/mjml.js
+++ b/src/helpers/mjml.js
@@ -33,6 +33,7 @@ export default function(mjmlContent, filePath, mjmlPath = null, options = {}) {
             '-s',
             '--config.validationLevel=skip',
             ...(options.minify ? ['-m'] : []),
+            ...(options.keepComments ? [] : ['--config.keepComments=0']),
             ...mjmlConfigOption,
           ]
 

--- a/src/helpers/mjml.js
+++ b/src/helpers/mjml.js
@@ -68,6 +68,7 @@ export default function(mjmlContent, filePath, mjmlPath = null, options = {}) {
           const mjmlOptions = {
             filePath,
             minify: !!options.minify,
+            keepComments: !!options.keepComments,
             mjmlConfigPath: useMjmlConfig
               ? settings.mjml.mjmlConfigPath || path.dirname(filePath)
               : null,


### PR DESCRIPTION
Here is the start of adding an option to disable the default keepComments option when the app calls the CLI. So far, the setting is added and stored, but the update to push this setting to the CLI is still in progress for `src/helpers/mjml.js`.